### PR TITLE
Improve json rpc

### DIFF
--- a/StarkSharp/StarkSharp.Rpc/JsonRpc.cs
+++ b/StarkSharp/StarkSharp.Rpc/JsonRpc.cs
@@ -30,7 +30,47 @@ namespace StarkSharp.Rpc
 
     public class JsonRpcHandler
     {
-        public static JsonRpc GenerateRequestData(string contractAddress, string entryPointSelector, string serializedData)
+        public static JsonRpc GenerateRequestData(string method, object data)
+        {
+            try
+            {
+                object[] refinedData;
+                if (data.GetType().IsArray)
+                {
+                    refinedData = new object[((object[])data).Length];
+                    for (int i = 0; i < ((object[])data).Length; i++)
+                    {
+                        if (((object[])data)[i].GetType() == typeof(string))
+                        {
+                            refinedData[i] = ((string)((object[])data)[i]).Trim();
+                        }
+                        else
+                        {
+                            refinedData[i] = ((object[])data)[i];
+                        }
+                    }
+                }
+                else
+                {
+                    refinedData = new object[] { data };
+                }
+
+                var requestData = new JsonRpc
+                {
+                    id = 1,
+                    method = method,
+                    @params = refinedData
+                };
+
+                return requestData;
+            }
+            catch (Exception ex)
+            {
+                Notify.ShowNotification($"Error generating request data: {ex.Message}", NotificationType.Error, NotificationPlatform.Console);
+                return null;
+            }
+        }
+        public static JsonRpc GenerateContractRequestData(string contractAddress, string entryPointSelector, string serializedData)
         {
             try
             {

--- a/StarkSharp/StarkSharp.Rpc/JsonRpc.cs
+++ b/StarkSharp/StarkSharp.Rpc/JsonRpc.cs
@@ -17,7 +17,7 @@ namespace StarkSharp.Rpc
     {
         public string jsonrpc { get; set; }
         public int id { get; set; }
-        public List<string> result { get; set; }
+        public object result { get; set; }
         public JsonRpcError error { get; set; }
     }
 


### PR DESCRIPTION
1. The current `JsonRpcResponse` class assumes that `result` is always a `List`. That's wrong and currently causes some errors.
2. Added `GenerateRequestData` to aid the composition of other rpc requests besides `starknet_call`